### PR TITLE
Remove googleplus

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ Facebook: <https://www.facebook.com/CreativeTim>
 
 Dribbble: <https://dribbble.com/creativetim>
 
-Google+: <https://plus.google.com/+CreativetimPage>
-
 Instagram: <https://instagram.com/creativetimofficial>
 
 [CHANGELOG]: ./CHANGELOG.md


### PR DESCRIPTION
Google plus is dead - those links can be removed because they also don't work.